### PR TITLE
Remove hardcoded directories, update indentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*-master.txt
+*-passwords.txt
+*-users.txt

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # breach-parse
 A tool for parsing breached passwords
 
-# Installation
+### Installation
+
 Download breached password list from magnet located here: https://github.com/philipperemy/tensorflow-1.4-billion-password-analysis
 
-Store downloaded list in /opt/breach-parse
+If you don't store the password list (BreachCompilation) in `/opt/breach-parse`, specify the location like: 
 
-Store breach.parse.sh in /opt/breach-parse
+`./breach-parse.sh @gmail.com gmail.txt "~/Downloads/BreachCompilation/data"`
 
-# To-Do (Future improvements)
-Remove hardcoded directories
+Run `./breach-parse.sh` for instructions
+
+### To-Do (Future improvements)
 
 Create auto-installer for alias

--- a/breach-parse.sh
+++ b/breach-parse.sh
@@ -32,7 +32,7 @@ else
         fi
     else
         if [ ! -d "${breachDataLocation}" ]; then
-            echo "Could not find a direcotry at ${breachDataLocation}"
+            echo "Could not find a directory at ${breachDataLocation}"
             echo 'Put the breached password list there or specify the location of the BreachCompilation/data as the third argument'
             echo 'Example: ./breach-parse.sh @gmail.com gmail.txt "~/Downloads/BreachCompilation/data"'
             exit 1

--- a/breach-parse.sh
+++ b/breach-parse.sh
@@ -1,31 +1,63 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-if [ "$#" != "2" ]; then
+if [ $# -lt 2 ]; then
         echo "Breach-Parse v2: A Breached Domain Parsing Tool by Heath Adams"
         echo " "
-        echo "Usage: ./breach-parse.sh <domain to search> <file to output>"
+        echo "Usage: ./breach-parse.sh <domain to search> <file to output> [breach data location]"
         echo "Example: ./breach-parse.sh @gmail.com gmail.txt"
+        echo 'Example: ./breach-parse.sh @gmail.com gmail.txt "~/Downloads/BreachCompilation/data"'
+        echo "You only need to specify [breach data location] if its not in the expected location (/opt/breach-parse/BreachCompilation/data)"
         echo " "
         echo 'For multiple domains: ./breach-parse.sh "<domain to search>|<domain to search>" <file to output>'
-        echo 'Exmple: ./breach-parse.sh "@gmail.com|@yahoo.com" multiple.txt'
+        echo 'Example: ./breach-parse.sh "@gmail.com|@yahoo.com" multiple.txt'
         exit 1
-
 else
+        if [ $# -ge 4 ]; then
+          echo 'You supplied more than 3 arguments, make sure to double quote your strings:'
+          echo 'Example: ./breach-parse.sh @gmail.com gmail.txt "~/Downloads/Temp Files/BreachCompilation"'
+          exit 1
+        fi
+
+        # assume default location
+        breachDataLocation="/opt/breach-parse/BreachCompilation/data"
+        # check if BreachCompilation was specified to be somewhere else
+        if [ $# -eq 3 ]; then
+          if [ -d "$3" ]; then
+            breachDataLocation="$3"
+          else
+            echo "Could not find a directory at ${3}"
+            echo 'Pass the BreachCompilation/data directory as the third argument'
+            echo 'Example: ./breach-parse.sh @gmail.com gmail.txt "~/Downloads/BreachCompilation/data"'
+            exit 1
+          fi
+        else
+          if [ ! -d "${breachDataLocation}" ]; then
+            echo "Could not find a direcotry at ${breachDataLocation}"
+            echo 'Put the breached password list there or specify the location of the BreachCompilation/data as the third argument'
+            echo 'Example: ./breach-parse.sh @gmail.com gmail.txt "~/Downloads/BreachCompilation/data"'
+            exit 1
+          fi
+        fi
+
+
+        # set output filenames
         fullfile=$2
         fbname=$(basename "$fullfile" | cut -d. -f1)
         master=$fbname-master.txt
         users=$fbname-users.txt
         passwords=$fbname-passwords.txt
-
+        
         touch $master
-        total_Files=$(find /opt/breach-parse/BreachCompilation/data -type f | wc -l)
+        # count files for progressBar
+        # -not -path '*/\.*' ignores hidden files/directories that may have been created by the OS
+        total_Files=$(find "$breachDataLocation" -type f -not -path '*/\.*' | wc -l)
         file_Count=0
 
         function ProgressBar {
 
-                let _progress=(${file_Count}*100/${total_Files}*100)/100
-                let _done=(${_progress}*4)/10
-                let _left=40-$_done
+                let _progress=$(( ( file_Count * 100 / total_Files * 100 ) / 100 ))
+                let _done=$(( ( _progress * 4 ) / 10 ))
+                let _left=$(( 40 - _done ))
 
                 _fill=$(printf "%${_done}s")
                 _empty=$(printf "%${_left}s")
@@ -34,8 +66,8 @@ else
 
         }
 
-
-        find /opt/breach-parse/BreachCompilation/data -type f -print0 | while read -d $'\0' file
+        # grep for passwords
+        find "$breachDataLocation" -type f -not -path '*/\.*' -print0 | while read -d $'\0' file
 
         do
                 grep -a -E "$1" "$file" >> $master
@@ -47,10 +79,13 @@ fi
 
 sleep 3
 
+echo # newline
+echo "Extracting usernames..."
 awk -F':' '{print $1}' $master > $users
 
 sleep 1
 
+echo "Extracting passwords..."
 awk -F':' '{print $2}' $master > $passwords
 echo
 exit 0

--- a/breach-parse.sh
+++ b/breach-parse.sh
@@ -1,94 +1,88 @@
 #!/usr/bin/env bash
 
 if [ $# -lt 2 ]; then
-        echo "Breach-Parse v2: A Breached Domain Parsing Tool by Heath Adams"
-        echo " "
-        echo "Usage: ./breach-parse.sh <domain to search> <file to output> [breach data location]"
-        echo "Example: ./breach-parse.sh @gmail.com gmail.txt"
-        echo 'Example: ./breach-parse.sh @gmail.com gmail.txt "~/Downloads/BreachCompilation/data"'
-        echo "You only need to specify [breach data location] if its not in the expected location (/opt/breach-parse/BreachCompilation/data)"
-        echo " "
-        echo 'For multiple domains: ./breach-parse.sh "<domain to search>|<domain to search>" <file to output>'
-        echo 'Example: ./breach-parse.sh "@gmail.com|@yahoo.com" multiple.txt'
-        exit 1
+    echo "Breach-Parse v2: A Breached Domain Parsing Tool by Heath Adams"
+    echo " "
+    echo "Usage: ./breach-parse.sh <domain to search> <file to output> [breach data location]"
+    echo "Example: ./breach-parse.sh @gmail.com gmail.txt"
+    echo 'Example: ./breach-parse.sh @gmail.com gmail.txt "~/Downloads/BreachCompilation/data"'
+    echo "You only need to specify [breach data location] if its not in the expected location (/opt/breach-parse/BreachCompilation/data)"
+    echo " "
+    echo 'For multiple domains: ./breach-parse.sh "<domain to search>|<domain to search>" <file to output>'
+    echo 'Example: ./breach-parse.sh "@gmail.com|@yahoo.com" multiple.txt'
+    exit 1
 else
-        if [ $# -ge 4 ]; then
-          echo 'You supplied more than 3 arguments, make sure to double quote your strings:'
-          echo 'Example: ./breach-parse.sh @gmail.com gmail.txt "~/Downloads/Temp Files/BreachCompilation"'
-          exit 1
-        fi
+    if [ $# -ge 4 ]; then
+        echo 'You supplied more than 3 arguments, make sure to double quote your strings:'
+        echo 'Example: ./breach-parse.sh @gmail.com gmail.txt "~/Downloads/Temp Files/BreachCompilation"'
+        exit 1
+    fi
 
-        # assume default location
-        breachDataLocation="/opt/breach-parse/BreachCompilation/data"
-        # check if BreachCompilation was specified to be somewhere else
-        if [ $# -eq 3 ]; then
-          if [ -d "$3" ]; then
+    # assume default location
+    breachDataLocation="/opt/breach-parse/BreachCompilation/data"
+    # check if BreachCompilation was specified to be somewhere else
+    if [ $# -eq 3 ]; then
+        if [ -d "$3" ]; then
             breachDataLocation="$3"
-          else
+        else
             echo "Could not find a directory at ${3}"
             echo 'Pass the BreachCompilation/data directory as the third argument'
             echo 'Example: ./breach-parse.sh @gmail.com gmail.txt "~/Downloads/BreachCompilation/data"'
             exit 1
-          fi
-        else
-          if [ ! -d "${breachDataLocation}" ]; then
+        fi
+    else
+        if [ ! -d "${breachDataLocation}" ]; then
             echo "Could not find a direcotry at ${breachDataLocation}"
             echo 'Put the breached password list there or specify the location of the BreachCompilation/data as the third argument'
             echo 'Example: ./breach-parse.sh @gmail.com gmail.txt "~/Downloads/BreachCompilation/data"'
             exit 1
-          fi
         fi
+    fi
 
+    # set output filenames
+    fullfile=$2
+    fbname=$(basename "$fullfile" | cut -d. -f1)
+    master=$fbname-master.txt
+    users=$fbname-users.txt
+    passwords=$fbname-passwords.txt
 
-        # set output filenames
-        fullfile=$2
-        fbname=$(basename "$fullfile" | cut -d. -f1)
-        master=$fbname-master.txt
-        users=$fbname-users.txt
-        passwords=$fbname-passwords.txt
-        
-        touch $master
-        # count files for progressBar
-        # -not -path '*/\.*' ignores hidden files/directories that may have been created by the OS
-        total_Files=$(find "$breachDataLocation" -type f -not -path '*/\.*' | wc -l)
-        file_Count=0
+    touch $master
+    # count files for progressBar
+    # -not -path '*/\.*' ignores hidden files/directories that may have been created by the OS
+    total_Files=$(find "$breachDataLocation" -type f -not -path '*/\.*' | wc -l)
+    file_Count=0
 
-        function ProgressBar {
+    function ProgressBar() {
 
-                let _progress=$(( ( file_Count * 100 / total_Files * 100 ) / 100 ))
-                let _done=$(( ( _progress * 4 ) / 10 ))
-                let _left=$(( 40 - _done ))
+        let _progress=$(((file_Count * 100 / total_Files * 100) / 100))
+        let _done=$(((_progress * 4) / 10))
+        let _left=$((40 - _done))
 
-                _fill=$(printf "%${_done}s")
-                _empty=$(printf "%${_left}s")
+        _fill=$(printf "%${_done}s")
+        _empty=$(printf "%${_left}s")
 
         printf "\rProgress : [${_fill// /\#}${_empty// /-}] ${_progress}%%"
 
-        }
+    }
 
-        # grep for passwords
-        find "$breachDataLocation" -type f -not -path '*/\.*' -print0 | while read -d $'\0' file
+    # grep for passwords
+    find "$breachDataLocation" -type f -not -path '*/\.*' -print0 | while read -d $'\0' file; do
+        grep -a -E "$1" "$file" >>$master
+        ((++file_Count))
+        ProgressBar ${number} ${total_Files}
 
-        do
-                grep -a -E "$1" "$file" >> $master
-                ((++file_Count))
-                ProgressBar ${number} ${total_Files}
-
-        done
+    done
 fi
 
 sleep 3
 
 echo # newline
 echo "Extracting usernames..."
-awk -F':' '{print $1}' $master > $users
+awk -F':' '{print $1}' $master >$users
 
 sleep 1
 
 echo "Extracting passwords..."
-awk -F':' '{print $2}' $master > $passwords
+awk -F':' '{print $2}' $master >$passwords
 echo
 exit 0
-
-
-


### PR DESCRIPTION
Hi, this PR allows you to pass the location of the BreachCompilation/data directory as the third argument, like:

`./breach-parse.sh @gmail.com gmail.txt "~/Downloads/BreachCompilation/data"`

If you don't supply the location, it assumes its in `/opt/breach-parse/BreachCompilation/data` like before.

I also:

- removed the 'remove hardcoded directories' from the todo on the README
- updated and fixed some spelling errors in the documentation
- added `-not -path '*/\.*'` to the `find` commands to ignore hidden files that may have been created by the OS
- updated the `progressBar` function to use the double parenthesis construct for math `$(( ))`
- changed the `#!/bin/bash` to `#!/usr/bin/env bash` incase for some reason bash isn't at `/bin/bash`
- added some `echo` statements when the `awk` commands are running to let to user know that usernames/passwords are being extracted
- added a gitignore so that the `master.txt`, `passwords.txt` and `users.txt` files dont sync to Github.

This looks like I've changed much more than I have since I also normalized the indentation to four spaces, you can see major changes I did [here](https://github.com/hmaverickadams/breach-parse/commit/12cde30b29161a3f0651391fd7b237e1f565fc57#diff-b224471a3b3a85db13c07ca50993e58eL1).

Please let me know if you want me to update anything.