### PR TITLE
Case Insensitive breach-parse.sh

### DIFF
--- a/breach-parse.sh
+++ b/breach-parse.sh
@@ -67,7 +67,7 @@ else
 
     # grep for passwords
     find "$breachDataLocation" -type f -not -path '*/\.*' -print0 | while read -d $'\0' file; do
-        grep -a -E "$1" "$file" >>$master
+        grep -i -a -E "$1" "$file" >>$master
         ((++file_Count))
         ProgressBar ${number} ${total_Files}
 


### PR DESCRIPTION
Added the `-i` flag to the main `grep` command to make the search case insensitive.

Searching for `@example.com` will now also return instances of `@EXAMPLE.com`, that may have otherwise been missed.